### PR TITLE
Update hardcoded localhost to use env var and updated Types

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,6 +1,6 @@
 DB_USER=
 DB_PASSWORD=
-API_PATH=http://localhost:3000/dev/api
+API_PATH=http://localhost:3000/api
 UI_PATH=http://localhost:3000
 JWT_SECRET=secret
 ALLOWED_GROUPS=housing-officer-dev,area-housing-manager-dev
@@ -8,3 +8,4 @@ FEEDBACK_LINK=https://docs.google.com/forms/
 CRM_CLOUD_URL=http://example.com
 CRM_CLOUD_AUTHORIZATION=secret
 CRM_API_URL=http://differentexample.com
+NEXT_PUBLIC_API_PATH=http://localhost:3000/api

--- a/src/mappings/apiTaskToUiTask.ts
+++ b/src/mappings/apiTaskToUiTask.ts
@@ -2,7 +2,7 @@ import { Row } from "../components/worktray";
 import { Stage, Task } from "../interfaces/task";
 import { Status } from "lbh-frontend-react";
 
-const apiTaskToUiTask = (apiTasks: Task[]) => {
+const apiTaskToUiTask = (apiTasks: Task[]): Row[] => {
   const mappedTasks: Row[] = [];
 
   apiTasks.forEach((element: Task) => {

--- a/src/usecases/ui/getTasks.test.ts
+++ b/src/usecases/ui/getTasks.test.ts
@@ -9,6 +9,12 @@ describe("getTasks", () => {
     axios.mockClear();
   })
 
+  it("returns an empty array when no env var is set", async () => {
+    const response = await getTasks();
+
+    expect(response).toEqual([]);
+  })
+
   it('successfully fetches data from an API', async () => {
     process.env.NEXT_PUBLIC_API_PATH = "http://localhost:3000/api"
 

--- a/src/usecases/ui/getTasks.test.ts
+++ b/src/usecases/ui/getTasks.test.ts
@@ -10,6 +10,8 @@ describe("getTasks", () => {
   })
 
   it('successfully fetches data from an API', async () => {
+    process.env.NEXT_PUBLIC_API_PATH = "http://localhost:3000/api"
+
     const data = mockApiTaskResponse()
 
     axios.get.mockResolvedValue(data);

--- a/src/usecases/ui/getTasks.ts
+++ b/src/usecases/ui/getTasks.ts
@@ -1,11 +1,15 @@
 import axios from 'axios';
 import apiTaskToUiTask from '../../mappings/apiTaskToUiTask';
+import { Row } from '../../components/worktray';
 
-const getTasks = async () => {
+const getTasks = async (): Promise<Row[]> => {
+  if(process.env.NEXT_PUBLIC_API_PATH === undefined) {
+    return [];
+  }
+
   const tasks: any = await axios
-    .get(`http://localhost:3000/api/tasks?patchId=hardcoded`)
+    .get(`${process.env.NEXT_PUBLIC_API_PATH}/tasks?patchId=hardcoded`)
     .then((response => {
-      console.log(response);
       return response;
     }))
 


### PR DESCRIPTION
# What?

Removes hardcoded localhost string in getTasks UI usecase.

# Why?

Allows us to set the API URL via an env var, meaning this usecase can run in different environments

# Checklist

- [x] Unit tests
- [ ] Integration tests
- [ ] Cypress tests

# Next steps

- [ ] Add env vars to hosted environments
  
