### PR TITLE
Tidy up CRM FetchXML queries

### DIFF
--- a/src/gateways/crmGateway.ts
+++ b/src/gateways/crmGateway.ts
@@ -17,8 +17,10 @@ class CrmGateway implements CrmGatewayInterface {
   public async getTasksByPatchId(patchId: string): Promise<GetTasksResponse> {
     const crmTokenGateway = new CrmTokenGateway();
     const crmApiToken = await crmTokenGateway.getCloudToken();
+    const crmQuery = getTasksByPatchId.replace("{{patchId}}", patchId); 
+
     const response = await axios
-      .get(`${process.env.CRM_API_URL}/api/data/v8.2/hackney_tenancymanagementinteractionses?fetchXml=${getTasksByPatchId}`, {
+      .get(`${process.env.CRM_API_URL}/api/data/v8.2/hackney_tenancymanagementinteractionses?fetchXml=${crmQuery}`, {
         headers: {
           "Authorization": `Bearer ${crmApiToken.token}`,
           "Prefer": "odata.include-annotations=\"OData.Community.Display.V1.FormattedValue\""

--- a/src/gateways/crmGateway.ts
+++ b/src/gateways/crmGateway.ts
@@ -2,7 +2,7 @@ import axios, { AxiosError } from 'axios';
 import CrmTokenGateway from "./crmTokenGateway";
 import { Task } from '../interfaces/task';
 import crmResponseToTask, { CrmResponseInterface } from '../mappings/crmToTask';
-import { getTasksByPatchId } from './xmlQueryStrings/getTasksByPatchId';
+import getTasksByPatchIdQuery from './xmlQueryStrings/getTasksByPatchId';
 
 interface GetTasksResponse {
   body: Task[] | undefined;
@@ -17,7 +17,7 @@ class CrmGateway implements CrmGatewayInterface {
   public async getTasksByPatchId(patchId: string): Promise<GetTasksResponse> {
     const crmTokenGateway = new CrmTokenGateway();
     const crmApiToken = await crmTokenGateway.getCloudToken();
-    const crmQuery = getTasksByPatchId.replace("{{patchId}}", patchId); 
+    const crmQuery = getTasksByPatchIdQuery(patchId); 
 
     const response = await axios
       .get(`${process.env.CRM_API_URL}/api/data/v8.2/hackney_tenancymanagementinteractionses?fetchXml=${crmQuery}`, {
@@ -41,6 +41,7 @@ class CrmGateway implements CrmGatewayInterface {
         };
       });
     return response;
+    
   }
 }
 

--- a/src/gateways/xmlQueryStrings/getTasksByPatchId.ts
+++ b/src/gateways/xmlQueryStrings/getTasksByPatchId.ts
@@ -27,7 +27,7 @@ return(
             <attribute name="hackney_traid" />
             <attribute name="hackney_issuelocation" />
             <filter>
-                <condition attribute="hackney_estateofficerpatchid" operator="eq" value="` + patchId + `" />
+                <condition attribute="hackney_estateofficerpatchid" operator="eq" value="${patchId}" />
             </filter>
             <link-entity name="contact" from="contactid" to="hackney_contactid" link-type="outer">
                 <attribute name="address1_line3" />

--- a/src/gateways/xmlQueryStrings/getTasksByPatchId.ts
+++ b/src/gateways/xmlQueryStrings/getTasksByPatchId.ts
@@ -1,1 +1,43 @@
-export const getTasksByPatchId = "<fetch%20top%3D%2710%27%3E%3Centity%20name%3D%27hackney_tenancymanagementinteractions%27%3E%20%3Cattribute%20name%3D%27hackney_contactid%27%20%2F%3E%20%3Cattribute%20name%3D%27hackney_handleby%27%20%2F%3E%20%3Cattribute%20name%3D%27hackney_areaname%27%20%2F%3E%20%3Cattribute%20name%3D%27hackney_name%27%20%2F%3E%20%3Cattribute%20name%3D%27statecode%27%20%2F%3E%20%3Cattribute%20name%3D%27hackney_estateofficerpatchid%27%20%2F%3E%20%3Cattribute%20name%3D%27hackney_natureofenquiry%27%20%2F%3E%20%3Cattribute%20name%3D%27createdon%27%20%2F%3E%20%3Cattribute%20name%3D%27hackney_estateofficer_createdbyid%27%20%2F%3E%20%3Cattribute%20name%3D%27hackney_estateofficer_updatedbyid%27%20%2F%3E%20%3Cattribute%20name%3D%27hackney_tenancymanagementinteractionsid%27%20%2F%3E%20%3Cattribute%20name%3D%27hackney_enquirysubject%27%20%2F%3E%20%3Cattribute%20name%3D%27hackney_managerpropertypatchid%27%20%2F%3E%20%3Cattribute%20name%3D%27hackney_contactid%27%20%2F%3E%20%3Cattribute%20name%3D%27hackney_handlebyname%27%20%2F%3E%20%3Cattribute%20name%3D%27hackney_incidentid%27%20%2F%3E%20%3Cattribute%20name%3D%27hackney_transferred%27%20%2F%3E%20%3Cattribute%20name%3D%27hackney_process_stage%27%20%2F%3E%20%3Cattribute%20name%3D%27hackney_household_interactionid%27%20%2F%3E%20%3Cattribute%20name%3D%27hackney_parent_interactionid%27%20%2F%3E%20%3Cattribute%20name%3D%27hackney_traid%27%20%2F%3E%20%3Cattribute%20name%3D%27hackney_issuelocation%27%20%2F%3E%3Cfilter%3E%3Ccondition%20attribute%3D%22hackney_estateofficerpatchid%22%20operator%3D%22eq%22%20value%3D%229cd3823d-8653-e811-8126-70106faaf8c1%22%20%2F%3E%3C%2Ffilter%3E%3Clink-entity%20name%3D%27contact%27%20from%3D%27contactid%27%20to%3D%27hackney_contactid%27%20link-type%3D%27outer%27%20%3E%20%3Cattribute%20name%3D%27address1_line3%27%20%2F%3E%20%3Cattribute%20name%3D%27address1_postalcode%27%20%2F%3E%20%3Cattribute%20name%3D%27address1_city%27%20%2F%3E%20%3Cattribute%20name%3D%27emailaddress1%27%20%2F%3E%20%3Cattribute%20name%3D%27telephone1%27%20%2F%3E%20%3Cattribute%20name%3D%27address1_line1%27%20%2F%3E%20%3Cattribute%20name%3D%27hackney_larn%27%20%2F%3E%20%3Cattribute%20name%3D%27hackney_uprn%27%20%2F%3E%20%3Cattribute%20name%3D%27address1_line2%27%20%2F%3E%3C%2Flink-entity%3E%3C%2Fentity%3E%3C%2Ffetch>"
+export const getTasksByPatchId = 
+`
+<fetch top="10">
+   <entity name="hackney_tenancymanagementinteractions">
+      <attribute name="hackney_contactid" />
+      <attribute name="hackney_handleby" />
+      <attribute name="hackney_areaname" />
+      <attribute name="hackney_name" />
+      <attribute name="statecode" />
+      <attribute name="hackney_estateofficerpatchid" />
+      <attribute name="hackney_natureofenquiry" />
+      <attribute name="createdon" />
+      <attribute name="hackney_estateofficer_createdbyid" />
+      <attribute name="hackney_estateofficer_updatedbyid" />
+      <attribute name="hackney_tenancymanagementinteractionsid" />
+      <attribute name="hackney_enquirysubject" />
+      <attribute name="hackney_managerpropertypatchid" />
+      <attribute name="hackney_contactid" />
+      <attribute name="hackney_handlebyname" />
+      <attribute name="hackney_incidentid" />
+      <attribute name="hackney_transferred" />
+      <attribute name="hackney_process_stage" />
+      <attribute name="hackney_household_interactionid" />
+      <attribute name="hackney_parent_interactionid" />
+      <attribute name="hackney_traid" />
+      <attribute name="hackney_issuelocation" />
+      <filter>
+         <condition attribute="hackney_estateofficerpatchid" operator="eq" value="{{patchId}}" />
+      </filter>
+      <link-entity name="contact" from="contactid" to="hackney_contactid" link-type="outer">
+         <attribute name="address1_line3" />
+         <attribute name="address1_postalcode" />
+         <attribute name="address1_city" />
+         <attribute name="emailaddress1" />
+         <attribute name="telephone1" />
+         <attribute name="address1_line1" />
+         <attribute name="hackney_larn" />
+         <attribute name="hackney_uprn" />
+         <attribute name="address1_line2" />
+      </link-entity>
+   </entity>
+</fetch>
+`

--- a/src/gateways/xmlQueryStrings/getTasksByPatchId.ts
+++ b/src/gateways/xmlQueryStrings/getTasksByPatchId.ts
@@ -1,43 +1,49 @@
-export const getTasksByPatchId = 
-`
-<fetch top="10">
-   <entity name="hackney_tenancymanagementinteractions">
-      <attribute name="hackney_contactid" />
-      <attribute name="hackney_handleby" />
-      <attribute name="hackney_areaname" />
-      <attribute name="hackney_name" />
-      <attribute name="statecode" />
-      <attribute name="hackney_estateofficerpatchid" />
-      <attribute name="hackney_natureofenquiry" />
-      <attribute name="createdon" />
-      <attribute name="hackney_estateofficer_createdbyid" />
-      <attribute name="hackney_estateofficer_updatedbyid" />
-      <attribute name="hackney_tenancymanagementinteractionsid" />
-      <attribute name="hackney_enquirysubject" />
-      <attribute name="hackney_managerpropertypatchid" />
-      <attribute name="hackney_contactid" />
-      <attribute name="hackney_handlebyname" />
-      <attribute name="hackney_incidentid" />
-      <attribute name="hackney_transferred" />
-      <attribute name="hackney_process_stage" />
-      <attribute name="hackney_household_interactionid" />
-      <attribute name="hackney_parent_interactionid" />
-      <attribute name="hackney_traid" />
-      <attribute name="hackney_issuelocation" />
-      <filter>
-         <condition attribute="hackney_estateofficerpatchid" operator="eq" value="{{patchId}}" />
-      </filter>
-      <link-entity name="contact" from="contactid" to="hackney_contactid" link-type="outer">
-         <attribute name="address1_line3" />
-         <attribute name="address1_postalcode" />
-         <attribute name="address1_city" />
-         <attribute name="emailaddress1" />
-         <attribute name="telephone1" />
-         <attribute name="address1_line1" />
-         <attribute name="hackney_larn" />
-         <attribute name="hackney_uprn" />
-         <attribute name="address1_line2" />
-      </link-entity>
-   </entity>
-</fetch>
-`
+const getTasksByPatchIdQuery = (patchId: string) => { 
+
+return(
+        `
+        <fetch top="10">
+        <entity name="hackney_tenancymanagementinteractions">
+            <attribute name="hackney_contactid" />
+            <attribute name="hackney_handleby" />
+            <attribute name="hackney_areaname" />
+            <attribute name="hackney_name" />
+            <attribute name="statecode" />
+            <attribute name="hackney_estateofficerpatchid" />
+            <attribute name="hackney_natureofenquiry" />
+            <attribute name="createdon" />
+            <attribute name="hackney_estateofficer_createdbyid" />
+            <attribute name="hackney_estateofficer_updatedbyid" />
+            <attribute name="hackney_tenancymanagementinteractionsid" />
+            <attribute name="hackney_enquirysubject" />
+            <attribute name="hackney_managerpropertypatchid" />
+            <attribute name="hackney_contactid" />
+            <attribute name="hackney_handlebyname" />
+            <attribute name="hackney_incidentid" />
+            <attribute name="hackney_transferred" />
+            <attribute name="hackney_process_stage" />
+            <attribute name="hackney_household_interactionid" />
+            <attribute name="hackney_parent_interactionid" />
+            <attribute name="hackney_traid" />
+            <attribute name="hackney_issuelocation" />
+            <filter>
+                <condition attribute="hackney_estateofficerpatchid" operator="eq" value="` + patchId + `" />
+            </filter>
+            <link-entity name="contact" from="contactid" to="hackney_contactid" link-type="outer">
+                <attribute name="address1_line3" />
+                <attribute name="address1_postalcode" />
+                <attribute name="address1_city" />
+                <attribute name="emailaddress1" />
+                <attribute name="telephone1" />
+                <attribute name="address1_line1" />
+                <attribute name="hackney_larn" />
+                <attribute name="hackney_uprn" />
+                <attribute name="address1_line2" />
+            </link-entity>
+        </entity>
+        </fetch>
+        `
+    )
+}
+
+export default getTasksByPatchIdQuery;


### PR DESCRIPTION
<!--
  Is this related to a ticket in Jira? If so, add Smart Commit commands to the
  PR title to be automatically included in the merge commit if the PR is merged.

  For example:

  MT3-221 #ready-for-test #comment Create a pull request template

  https://confluence.atlassian.com/fisheye/using-smart-commits-960155400.html
  -->

# What?
Update the FetchXML query string so it's easier to read. Also fix the issue where the patchid was hardcoded in the query. 
<!--
  What new features or changes does this pull request contain?

  Include before and after screenshots, if appropriate.
  -->

# Why?
Make the xml string more readable. Also make the patchid in the query dynamic rather than hard coded
<!--
  What motivates these changes?

  Include any user stories driving this feature, if appropriate.
  -->
  
# Notes
The query is currently limiting the number of results to 10 to make the data set handled during development more reasonable