### PR TITLE
Pull in Open Sans from Google Fonts as per main Hackney website

### DIFF
--- a/src/global.scss
+++ b/src/global.scss
@@ -1,3 +1,5 @@
+@import url(//fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,600italic,700italic,800italic,400,300,600,700,800&subset=cyrillic,latin,greek);
+
 body {
     margin: 0
 }


### PR DESCRIPTION
Quick fix to pull in fonts from CDN. URL copied form main Hackney website repository