### PR TITLE
Block Prod Deploy On Cypress Failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,6 +106,7 @@ workflows:
               only:
                 - master
       - cypress/run:
+          name: cypress-branch
           store_artifacts: false
           start: npm run dev
           requires:
@@ -115,6 +116,7 @@ workflows:
               ignore:
                 - master
       - cypress/run:
+          name: cypress-master
           store_artifacts: true
           requires:
             - deploy-staging
@@ -126,7 +128,7 @@ workflows:
           type: approval
           requires:
             - deploy-staging
-            - cypress/run
+            - cypress-master
       - deploy-production:
           requires:
             - permit-deploy-production

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,6 +126,7 @@ workflows:
           type: approval
           requires:
             - deploy-staging
+            - cypress/run
       - deploy-production:
           requires:
             - permit-deploy-production


### PR DESCRIPTION
<!--
  Is this related to a ticket in Jira? If so, add Smart Commit commands to the
  PR title to be automatically included in the merge commit if the PR is merged.

  For example:

  MT3-221 #ready-for-test #comment Create a pull request template

  https://confluence.atlassian.com/fisheye/using-smart-commits-960155400.html
  -->

# What?

Block promotion of staging build to to prod in CircleCI if the Cypress tests are not passing in the master branch.

<!--
  What new features or changes does this pull request contain?

  Include before and after screenshots, if appropriate.
  -->

# Why?

To prevent failing code from being deployed to prod.

<!--
  What motivates these changes?

  Include any user stories driving this feature, if appropriate.
  -->

# Checklist

<!-- Add 'x' to the tests you've created and provide additional comments where useful.
     e.g. - [x] Cypress tests - Login & Logout user journeys -->

- [ ] Unit tests
- [ ] Integration tests
- [x] Cypress tests

# Notes

<!--
  Is there anything about the implementation worth calling out to reviewers?
  -->

# Next steps

<!--
  Is there any follow up work that needs to be done?

  Consider using a checklist, for example:

  - [ ] do something
  - [ ] do something else
  -->
  
