### PR TITLE
SV-144 - Add a contacts API endpoint for use by single view

### DIFF
--- a/src/gateways/v1MatAPIGateway.test.ts
+++ b/src/gateways/v1MatAPIGateway.test.ts
@@ -116,17 +116,19 @@ describe('v1MatAPIGateway', () => {
 
     it('successfully returns data from an API', async () => {
       const dummyResponse = {
-        results: [
-          { contactId: faker.lorem.word() },
-          { contactId: faker.lorem.word() },
-        ],
+        data: {
+          results: [
+            { contactId: faker.lorem.word() },
+            { contactId: faker.lorem.word() },
+          ],
+        },
       };
 
       axios.get.mockResolvedValue(dummyResponse);
 
       const response = await gateway.getContactsByUprn('12345678901');
 
-      expect(response.body).toEqual(dummyResponse.results);
+      expect(response.body).toEqual(dummyResponse.data.results);
     });
 
     it('returns an human readable error when unsuccessful', async () => {

--- a/src/gateways/v1MatAPIGateway.ts
+++ b/src/gateways/v1MatAPIGateway.ts
@@ -1,6 +1,6 @@
 import axios, { AxiosError } from 'axios';
 import { Tenancy } from '../interfaces/tenancy';
-import { Contact } from '../interfaces/contact';
+import V1ApiContact from '../interfaces/v1ApiContact';
 import { TenancyManagementInteraction } from '../interfaces/tenancyManagementInteraction';
 
 export interface v1MatAPIGatewayInterface {
@@ -26,12 +26,12 @@ export interface v1MatAPIGatewayOptions {
 }
 
 interface GetContactsByUprnAPIResponse {
-  results?: Contact[];
+  results?: V1ApiContact[];
   error?: string;
 }
 
 export interface GetContactsByUprnResponse {
-  body?: Contact[];
+  body?: V1ApiContact[];
   error?: string;
 }
 
@@ -102,7 +102,7 @@ export default class v1MatAPIGateway implements v1MatAPIGatewayInterface {
         },
       })
       .then((response) => {
-        const data = response as GetContactsByUprnAPIResponse;
+        const data = response.data as GetContactsByUprnAPIResponse;
         return {
           body: data.results,
           error: undefined,

--- a/src/interfaces/v1ApiContact.ts
+++ b/src/interfaces/v1ApiContact.ts
@@ -1,19 +1,29 @@
-export interface Contact {
-  crmContactId: string;
+export default interface V1ApiContact {
+  contactId: string;
   emailAddress: string | null;
+  uprn: string;
   addressLine1: string;
   addressLine2: string;
   addressLine3: string;
   firstName: string;
   lastName: string;
+  fullName: string;
+  larn: string;
   telephone1: string | null;
   telephone2: string | null;
   telephone3: string | null;
+  cautionaryAlert: boolean;
+  propertyCautionaryAlert: boolean;
+  houseRef: string | null;
   title: string | null | undefined;
+  fullAddressDisplay?: string;
+  fullAddressSearch: string;
   postCode: string;
   dateOfBirth: string;
+  hackneyHomesId: string;
   disabled: boolean;
   relationship: string | null;
   extendedrelationship: string | null;
   responsible: boolean;
+  age?: string;
 }

--- a/src/mappings/v1ApiContactToContact.test.ts
+++ b/src/mappings/v1ApiContactToContact.test.ts
@@ -1,0 +1,31 @@
+import v1ApiContactToContact from './v1ApiContactToContact';
+import Mockv1ApiContact from '../tests/helpers/generatev1ApiContact';
+import { Contact } from '../interfaces/contact';
+
+describe('tenancyToITVTask', () => {
+  it('returns a valid Contact when given a V1ApiContact', () => {
+    const v1Contact = Mockv1ApiContact(true);
+
+    const contact: Contact = v1ApiContactToContact(v1Contact);
+
+    expect(contact).toEqual({
+      addressLine1: '12',
+      addressLine2: 'STREET CLOSE',
+      addressLine3: 'HACKNEY',
+      crmContactId: 'contactId',
+      dateOfBirth: '1990-01-01',
+      disabled: false,
+      emailAddress: 'me@mail.com',
+      extendedrelationship: null,
+      firstName: 'David',
+      lastName: 'Jones',
+      postCode: 'E8 9XX',
+      relationship: null,
+      responsible: true,
+      telephone1: '12345678',
+      telephone2: null,
+      telephone3: null,
+      title: 'Mr',
+    });
+  });
+});

--- a/src/mappings/v1ApiContactToContact.ts
+++ b/src/mappings/v1ApiContactToContact.ts
@@ -1,0 +1,24 @@
+import { Contact } from '../interfaces/contact';
+import V1ApiContact from '../interfaces/v1ApiContact';
+
+export default (v1ApiContact: V1ApiContact): Contact => {
+  return {
+    crmContactId: v1ApiContact.contactId,
+    emailAddress: v1ApiContact.emailAddress,
+    addressLine1: v1ApiContact.addressLine1,
+    addressLine2: v1ApiContact.addressLine2,
+    addressLine3: v1ApiContact.addressLine3,
+    firstName: v1ApiContact.firstName,
+    lastName: v1ApiContact.lastName,
+    telephone1: v1ApiContact.telephone1,
+    telephone2: v1ApiContact.telephone2,
+    telephone3: v1ApiContact.telephone3,
+    title: v1ApiContact.title,
+    postCode: v1ApiContact.postCode,
+    dateOfBirth: v1ApiContact.dateOfBirth,
+    disabled: v1ApiContact.disabled,
+    relationship: v1ApiContact.relationship,
+    extendedrelationship: v1ApiContact.extendedrelationship,
+    responsible: v1ApiContact.responsible,
+  };
+};

--- a/src/pages/api/contacts.ts
+++ b/src/pages/api/contacts.ts
@@ -1,0 +1,31 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+import v1MatAPIGateway from '../../gateways/v1MatAPIGateway';
+import v1ApiContactToContact from '../../mappings/v1ApiContactToContact';
+
+export default async (req: NextApiRequest, res: NextApiResponse) => {
+  const uprn = req.query.uprn
+    ? Array.isArray(req.query.uprn)
+      ? req.query.uprn[0]
+      : req.query.uprn
+    : undefined;
+
+  if (!uprn) return res.status(400).json({ error: 'UPRN missing' });
+  if (!process.env.V1_MAT_API_URL || !process.env.V1_MAT_API_TOKEN) {
+    return res.status(500).end();
+  }
+
+  const gateway: v1MatAPIGateway = new v1MatAPIGateway({
+    v1MatApiUrl: process.env.V1_MAT_API_URL,
+    v1MatApiToken: process.env.V1_MAT_API_TOKEN,
+  });
+
+  const response = await gateway.getContactsByUprn(uprn);
+
+  if (response.body) {
+    res
+      .status(200)
+      .json({ contacts: response.body.map(v1ApiContactToContact) });
+  } else {
+    res.status(500).json({ error: 'Could not retrieve contacts' });
+  }
+};

--- a/src/tests/helpers/generatev1ApiContact.ts
+++ b/src/tests/helpers/generatev1ApiContact.ts
@@ -1,0 +1,33 @@
+import V1ApiContact from '../../interfaces/v1ApiContact';
+
+export default (): V1ApiContact => {
+  return {
+    contactId: 'contactId',
+    emailAddress: 'me@mail.com',
+    uprn: '100000000000',
+    addressLine1: '12',
+    addressLine2: 'STREET CLOSE',
+    addressLine3: 'HACKNEY',
+    firstName: 'David',
+    lastName: 'Jones',
+    fullName: 'David Jones',
+    larn: 'LARN12345678',
+    telephone1: '12345678',
+    telephone2: null,
+    telephone3: null,
+    cautionaryAlert: false,
+    propertyCautionaryAlert: false,
+    houseRef: null,
+    title: 'Mr',
+    fullAddressDisplay: '12\r\nSTREET CLOSE\r\nHACKNEY\r\nLONDON E8 9XX',
+    fullAddressSearch: '12streetclose',
+    postCode: 'E8 9XX',
+    dateOfBirth: '1990-01-01',
+    hackneyHomesId: '123456',
+    disabled: false,
+    relationship: null,
+    extendedrelationship: null,
+    responsible: true,
+    age: '20',
+  };
+};


### PR DESCRIPTION
# What?

Adds a /api/comments endpoint for Single View to use to fetch the most up to date contacts from the v1 MaT API. I thought it best to reduce the number of systems accessing the V1 MaT API so preferred SV to go through the MaT Service API as it will be using it for other things too.

# Checklist

<!-- Add 'x' to the tests you've created and provide additional comments where useful.
     e.g. - [x] Cypress tests - Login & Logout user journeys -->

- [x] Unit tests
- [-] Integration tests
- [-] Cypress tests
