### PR TITLE
Temp deploy to staging from branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,7 +87,7 @@ jobs:
 
       - run:
           name: Run unit tests
-          command: npm run test:unit
+          command: npm run test:unit:ci
 
       - persist_to_workspace:
           root: ~/repo

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,10 +10,28 @@ executors:
     working_directory: ~/repo
 
 commands:
-  deploy-staging:
+  deploy:
+    parameters:
+      environment:
+        type: string
+      api_path:
+        type: string
     steps:
-      - attach_workspace:
-          at: ~/repo
+      - checkout
+
+      - run:
+          name: Concatenate all package-lock.json files into single file for checksum
+          command: cat package-lock.json > combined-package-lock.txt
+
+      - restore_cache:
+          keys:
+            - v1-dependencies-{{ checksum "combined-package-lock.txt" }}
+
+      - run:
+          name: Install dependencies
+          command: |
+            sudo CYPRESS_CACHE_FOLDER=~/repo npm i --no-cache git
+            sudo CYPRESS_CACHE_FOLDER=~/repo npm i
 
       - run:
           name: Set AWS credentials
@@ -23,11 +41,11 @@ commands:
       - run:
           name: Deploy application
           command: |
-            NEXT_PUBLIC_API_PATH=$API_PATH_STAGING npm run build && ./node_modules/serverless/bin/serverless.js deploy -s staging
+            NEXT_PUBLIC_API_PATH=${<< parameters.api_path >>} npm run build && ./node_modules/serverless/bin/serverless.js deploy -s << parameters.environment >>
 
       - run:
           name: Run integration tests
-          command: INTEGRATION_TEST_API_PATH=${API_PATH_STAGING} npm run test:integration
+          command: INTEGRATION_TEST_API_PATH=${<< parameters.api_path >>} npm run test:integration
 
 jobs:
   test:
@@ -78,46 +96,25 @@ jobs:
   deploy-staging:
     executor: my-executor
     steps:
-      - deploy-staging
+      - deploy:
+          environment: staging
+          api_path: API_PATH_STAGING
 
   temp-deploy-staging:
     executor: my-executor
     steps:
-      - deploy-staging
+      - deploy:
+          environment: staging
+          api_path: API_PATH_STAGING
 
   deploy-production:
     executor: my-executor
 
     steps:
+      - deploy:
+          environment: production
+          api_path: API_PATH_PRODUCTION
       - checkout
-
-      - run:
-          name: Concatenate all package-lock.json files into single file for checksum
-          command: cat package-lock.json > combined-package-lock.txt
-
-      - restore_cache:
-          keys:
-            - v1-dependencies-{{ checksum "combined-package-lock.txt" }}
-
-      - run:
-          name: Install dependencies
-          command: |
-            sudo CYPRESS_CACHE_FOLDER=~/repo npm i --no-cache git
-            sudo CYPRESS_CACHE_FOLDER=~/repo npm i
-
-      - run:
-          name: Set AWS credentials
-          command: |
-            pushd ~ && ./repo/node_modules/serverless/bin/serverless.js config credentials -p aws -k ${AWS_ACCESS_KEY_ID} -s ${AWS_SECRET_ACCESS_KEY} -n hackney && popd
-
-      - run:
-          name: Deploy application
-          command: |
-            NEXT_PUBLIC_API_PATH=$API_PATH_PRODUCTION npm run build && ./node_modules/serverless/bin/serverless.js deploy -s production
-
-      - run:
-          name: Run integration tests
-          command: INTEGRATION_TEST_API_PATH=${API_PATH_PRODUCTION} npm run test:integration
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,26 @@ executors:
       - image: circleci/node:12.13
     working_directory: ~/repo
 
+commands:
+  deploy-staging:
+    steps:
+      - attach_workspace:
+          at: ~/repo
+
+      - run:
+          name: Set AWS credentials
+          command: |
+            pushd ~ && ./repo/node_modules/serverless/bin/serverless.js config credentials -p aws -k ${AWS_ACCESS_KEY_ID} -s ${AWS_SECRET_ACCESS_KEY} -n hackney && popd
+
+      - run:
+          name: Deploy application
+          command: |
+            NEXT_PUBLIC_API_PATH=$API_PATH_STAGING npm run build && ./node_modules/serverless/bin/serverless.js deploy -s staging
+
+      - run:
+          name: Run integration tests
+          command: INTEGRATION_TEST_API_PATH=${API_PATH_STAGING} npm run test:integration
+
 jobs:
   test:
     executor: my-executor
@@ -57,24 +77,13 @@ jobs:
 
   deploy-staging:
     executor: my-executor
-
     steps:
-      - attach_workspace:
-          at: ~/repo
+      - deploy-staging
 
-      - run:
-          name: Set AWS credentials
-          command: |
-            pushd ~ && ./repo/node_modules/serverless/bin/serverless.js config credentials -p aws -k ${AWS_ACCESS_KEY_ID} -s ${AWS_SECRET_ACCESS_KEY} -n hackney && popd
-
-      - run:
-          name: Deploy application
-          command: |
-            NEXT_PUBLIC_API_PATH=$API_PATH_STAGING npm run build && ./node_modules/serverless/bin/serverless.js deploy -s staging
-
-      - run:
-          name: Run integration tests
-          command: INTEGRATION_TEST_API_PATH=${API_PATH_STAGING} npm run test:integration
+  temp-deploy-staging:
+    executor: my-executor
+    steps:
+      - deploy-staging
 
   deploy-production:
     executor: my-executor
@@ -146,6 +155,18 @@ workflows:
           requires:
             - deploy-staging
             - cypress-master
+      - permit-deploy-staging:
+          name: permit-deploy-staging
+          type: approval
+          requires:
+            - cypress-branch
+          filters:
+            branches:
+              ignore:
+                - master
+      - temp-deploy-staging:
+          requires:
+            - permit-deploy-staging
       - deploy-production:
           requires:
             - permit-deploy-production

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "start": "next start",
     "serverless:offline": "npm run build && serverless offline",
     "test:unit": "jest --config ./jest.unit.config.js",
+    "test:unit:ci": "jest --config ./jest.unit.config.js --maxWorkers=1",
     "test:unit:watch": "jest --config ./jest.unit.config.js --watch",
     "test:unit:coverage": "jest --config ./jest.unit.config.js --coverage",
     "test:integration": "jest --config ./jest.integration.config.js",


### PR DESCRIPTION
This adds the ability to deploy the code to staging from the pipeline that runs on branches so that you can check your work on staging before merging.

Use carefully - if any other PRs get merged they will deploy over staging - ideally we'd use another environment for this but for now this will suffice