### PR TITLE
Extract tag ref section to conditional render method

### DIFF
--- a/src/pages/tasks/[id].tsx
+++ b/src/pages/tasks/[id].tsx
@@ -65,6 +65,22 @@ export default function TaskPage() {
   };
 
   if (task) {
+    const renderTagRef = () => {
+      if (task.tenancy.tagRef) {
+        return (
+          <a
+            className="tenancy"
+            href={`${
+              process.env.NEXT_PUBLIC_SINGLEVIEW_URL
+            }/tenancies/${task.tenancy.tagRef.replace('/', '-')}`}
+          >
+            {task.tenancy.tagRef}
+          </a>
+        );
+      }
+      return null;
+    };
+
     return (
       <Layout>
         <Heading level={HeadingLevels.H2}>{task.type}</Heading>
@@ -79,14 +95,7 @@ export default function TaskPage() {
             ? moment(task.tenancy.startDate).format('DD/MM/YYYY')
             : 'n/a'}
           <Label>Tenancy Reference (Tag Ref):</Label>
-          <a
-            className="tenancy"
-            href={`${
-              process.env.NEXT_PUBLIC_SINGLEVIEW_URL
-            }/tenancies/${task.tenancy.tagRef.replace('/', '-')}`}
-          >
-            {task.tenancy.tagRef}
-          </a>
+          {renderTagRef()}
         </Paragraph>
         <Heading level={HeadingLevels.H3}>Residents</Heading>
         <div className="tile-container">


### PR DESCRIPTION
# What?

Moves tag ref section of task page to a render function.

# Why?

Allows for an undefined check of the field before the render, removing the build error for cases when it does not exist.
