### PR TITLE
Create a new return type and use it for crmTokenGateway

### DIFF
--- a/src/gateways/crmGateway.test.ts
+++ b/src/gateways/crmGateway.test.ts
@@ -21,9 +21,7 @@ jest.mock('../gateways/crmTokenGateway');
 describe('CrmGateway', () => {
   beforeEach(() => {
     axios.mockClear();
-    CrmTokenGateway.prototype.getToken.mockResolvedValue(() =>
-      Promise.resolve({ body: 'fakeToken' })
-    );
+    CrmTokenGateway.prototype.getToken.mockResolvedValue(() => 'fakeToken');
   });
 
   describe('Get Tasks by patch id', () => {

--- a/src/gateways/crmTokenGateway.test.ts
+++ b/src/gateways/crmTokenGateway.test.ts
@@ -1,6 +1,7 @@
 import CrmTokenGateway from './crmTokenGateway';
 import axios from 'axios';
 import faker from 'faker';
+import { isError } from '../lib/utils';
 jest.mock('axios');
 
 describe('TasksGateway', () => {
@@ -24,21 +25,17 @@ describe('TasksGateway', () => {
       const crmTokenGateway = new CrmTokenGateway();
       const response = await crmTokenGateway.getToken();
 
-      expect(response).toEqual({ body: token });
+      expect(response).toEqual(token);
     });
 
     it('returns an human readable error when unsuccessful', async () => {
       const errorMessage = 'Network Error';
-      const expectedErrorResponse = {
-        error: errorMessage,
-      };
-
       axios.post.mockReturnValue(Promise.reject(new Error(errorMessage)));
 
       const crmTokenGateway = new CrmTokenGateway();
       const response = await crmTokenGateway.getToken();
-
-      expect(response).toEqual(expectedErrorResponse);
+      expect(isError(response)).toBe(true);
+      expect(response.message).toEqual(errorMessage);
     });
   });
 });

--- a/src/gateways/crmTokenGateway.ts
+++ b/src/gateways/crmTokenGateway.ts
@@ -1,26 +1,22 @@
-import axios, { AxiosResponse, AxiosError } from 'axios';
+import axios, { AxiosError } from 'axios';
+import { Result } from '../lib/utils';
 
 interface GetTokenResponse {
   accessToken: string;
   expiresAt: string;
 }
-export interface CrmTokenGatewayResponse {
-  body?: string;
-  error?: string;
-}
 
 export interface CrmTokenGatewayInterface {
-  getToken(): Promise<CrmTokenGatewayResponse>;
+  getToken(): Promise<Result<string>>;
 }
 
-class CrmTokenGateway implements CrmTokenGatewayInterface {
-  public async getToken(): Promise<CrmTokenGatewayResponse> {
+export default class CrmTokenGateway implements CrmTokenGatewayInterface {
+  public async getToken(): Promise<Result<string>> {
     if (!process.env.CRM_TOKEN_API_URL || !process.env.CRM_TOKEN_API_KEY) {
-      return {
-        error: 'CRM token gateway configuration not set',
-      };
+      return new Error('CRM token gateway configuration not set');
     }
-    const response = await axios
+
+    return axios
       .post<GetTokenResponse>(
         process.env.CRM_TOKEN_API_URL,
         {},
@@ -30,14 +26,7 @@ class CrmTokenGateway implements CrmTokenGatewayInterface {
           },
         }
       )
-      .then((response) => {
-        return { body: response.data.accessToken };
-      })
-      .catch((error: AxiosError) => {
-        return { error: error.message };
-      });
-    return response;
+      .then((response) => response.data.accessToken)
+      .catch((error: AxiosError) => new Error(error.message));
   }
 }
-
-export default CrmTokenGateway;

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,9 @@
+export type Result<T> = T | Error;
+
+export function isError<T>(result: Result<T>): result is Error {
+  return result instanceof Error;
+}
+
+export function isSuccess<T>(result: Result<T>): result is T {
+  return !isError(result);
+}

--- a/src/pages/api/healthcheck.ts
+++ b/src/pages/api/healthcheck.ts
@@ -3,6 +3,7 @@ import CrmTokenGateway from '../../gateways/crmTokenGateway';
 import MatPostgresGateway from '../../gateways/matPostgresGateway';
 import v1MatAPIGateway from '../../gateways/v1MatAPIGateway';
 import CrmGateway from '../../gateways/crmGateway';
+import { isSuccess } from '../../lib/utils';
 
 type Data = {
   result: string;
@@ -100,7 +101,7 @@ const checkDynamicsToken: typeof CheckFn = async (): Promise<CheckResult> => {
   const checkPromise = new Promise(async (resolve, reject) => {
     const crmTokenGateway = new CrmTokenGateway();
     const response = await crmTokenGateway.getToken();
-    response.body ? resolve() : reject();
+    isSuccess(response) ? resolve() : reject();
   });
   return promiseTimeout(5000, checkPromise)
     .then(() => {


### PR DESCRIPTION
<!--
  Is this related to a ticket in Jira? If so, add Smart Commit commands to the
  PR title to be automatically included in the merge commit if the PR is merged.

  For example:

  MT3-221 #ready-for-test #comment Create a pull request template

  https://confluence.atlassian.com/fisheye/using-smart-commits-960155400.html
  -->

# What?
Refactor the return interface for crmTokenGateway as a test because I was finding the current implementation unwieldy.
<!--
  What new features or changes does this pull request contain?

  Include before and after screenshots, if appropriate.
  -->

# Why?
Returning either body or error means that you could return neither, so you need more checks to validate correctness. This adds a new generic Result type which either returns an object or an instance of the Error class. This means that we no longer need to access the result through the body attribute which simplifies the code a little. It also adds a couple of type guard functions to make life easier.

If we agree this is an improvement, then any new methods should use this approach and we should refactor the existing code.
<!--
  What motivates these changes?

  Include any user stories driving this feature, if appropriate.
  -->

# Checklist

<!-- Add 'x' to the tests you've created and provide additional comments where useful.
     e.g. - [x] Cypress tests - Login & Logout user journeys -->

- [x] Unit tests
- [ ] Integration tests
- [ ] Cypress tests

# Notes

<!--
  Is there anything about the implementation worth calling out to reviewers?
  -->

# Next steps

<!--
  Is there any follow up work that needs to be done?

  Consider using a checklist, for example:

  - [ ] do something
  - [ ] do something else
  -->
