### PR TITLE
Wrap pieces of render logic in Tile component to correct page layout

### DIFF
--- a/src/pages/tasks/[id]/index.tsx
+++ b/src/pages/tasks/[id]/index.tsx
@@ -185,8 +185,7 @@ export default function TaskPage() {
 
   const renderTenancyInfo = () => {
     return (
-      <div>
-        <Heading level={HeadingLevels.H3}>Tenancy</Heading>
+      <Tile title={'Tenancy'}>
         <Paragraph>
           <Label>Address:</Label>
           {task.address.presentationShort}
@@ -196,10 +195,10 @@ export default function TaskPage() {
           {task.tenancy.startDate
             ? moment(task.tenancy.startDate).format('DD/MM/YYYY')
             : 'n/a'}
-          <Label>Tenancy Reference (Tag Ref):</Label>
+          <Label>Tenancy reference:</Label>
           {renderTagRef()}
         </Paragraph>
-      </div>
+      </Tile>
     );
   };
 
@@ -269,26 +268,29 @@ export default function TaskPage() {
       {renderLaunchProcess()}
       <Heading level={HeadingLevels.H2}>{task.type}</Heading>
       {renderTenancyInfo()}
-      <Heading level={HeadingLevels.H3}>Residents</Heading>
-      <div className="tile-container">
-        {mapResidents(task.tenancy.residents)}
-      </div>
-      <Heading level={HeadingLevels.H3}>Action</Heading>
-      <Paragraph>
-        <Label>Due:</Label>
-        {task.dueTime ? task.dueTime : 'n/a'}
-        <Label>Reference number:</Label>
-        {task.referenceNumber ? task.referenceNumber : 'n/a'}
-        <Label>Related item:</Label>
-        {task.parent ? task.parent : 'n/a'}
-      </Paragraph>
-      <Heading level={HeadingLevels.H4}>Notes</Heading>
-      {renderNotes()}
-      {renderNotesUpdate()}
-      {task.assignedToManager
-        ? renderSelectAndSendToOfficer()
-        : renderSendToManager()}
-      {renderCloseTask()}
+      <Tile title={'Residents'}>
+        <div className="tile-container">
+          {mapResidents(task.tenancy.residents)}
+        </div>
+      </Tile>
+      <Tile title={'Actions'}>
+        <Paragraph>
+          <Label>Due:</Label>
+          {task.dueTime ? task.dueTime : 'n/a'}
+          <Label>Reference number:</Label>
+          {task.referenceNumber ? task.referenceNumber : 'n/a'}
+          <Label>Related item:</Label>
+          {task.parent ? task.parent : 'n/a'}
+        </Paragraph>
+      </Tile>
+      <Tile title={'Notes'}>
+        {renderNotes()}
+        {renderNotesUpdate()}
+        {task.assignedToManager
+          ? renderSelectAndSendToOfficer()
+          : renderSendToManager()}
+        {renderCloseTask()}
+      </Tile>
       <style jsx>{`
         .tile-container {
           display: flex;


### PR DESCRIPTION
#What

Wrap pieces of render logic in Tile component to bring page elements into line with one another

#Why

Update styling of 'Tenancy' details box - see https://projects.invisionapp.com/share/YCXWQIUQKDA#/screens/426412602_Action_Page-Created

Update styling of 'Residents' details box(es)  including removing vertical lines- see https://projects.invisionapp.com/share/YCXWQIUQKDA#/screens/426412602_Action_Page-Created

Can we use the same 'Resident card' that is on the 'Tenancy view' page for these details?
See also accessibility issue about text shouldn't be fully justified