### PR TITLE
SV211 Redirect to root page on successful transfer

### DIFF
--- a/src/pages/tasks/[id]/index.tsx
+++ b/src/pages/tasks/[id]/index.tsx
@@ -123,9 +123,13 @@ export default function TaskPage(): React.ReactNode {
   };
 
   const sendToManager = () => {
-    sendTaskToManager(task.id).catch(() => {
-      setError('sendToManagerError');
-    });
+    sendTaskToManager(task.id)
+      .then(() => {
+        router.push('/');
+      })
+      .catch(() => {
+        setError('sendToManagerError');
+      });
   };
 
   const closeTaskHandler = () => {


### PR DESCRIPTION
SV211

# What?

Redirects to the worktray page on a successful transfer to manager.

# Why?

Once transferred, the task no longer belongs to the original user, therefore we want to redirect to the worktray, where the task should no longer be present.
