### PR TITLE
Remove etra records from the worktray

### DIFF
--- a/src/gateways/xmlQueryStrings/getTasksByPatchAndOfficerId.ts
+++ b/src/gateways/xmlQueryStrings/getTasksByPatchAndOfficerId.ts
@@ -29,8 +29,11 @@ export default (
                 <attribute name="hackney_parent_interactionid" />
                 <attribute name="hackney_traid" />
                 <attribute name="hackney_issuelocation" />
-                <filter type="and">
+                <filter>
                     <condition attribute="hackney_estateofficerpatchid" value="${patchId}" operator="eq"/>
+                </filter>
+                <filter>
+                    <condition attribute="hackney_natureofenquiry" operator="neq" value="28" />
                 </filter>
                 <link-entity name="contact" from="contactid" to="hackney_contactid" link-type="outer">
                     <attribute name="fullname" alias="name"/>
@@ -75,6 +78,9 @@ export default (
                 <attribute name="hackney_issuelocation" />
                 <filter>
                     <condition attribute="hackney_managerpropertypatchid" operator="eq" value="${areaManagerId}" />
+                </filter>
+                <filter>
+                    <condition attribute="hackney_natureofenquiry" operator="neq" value="28" />
                 </filter>
                 <link-entity name="contact" from="contactid" to="hackney_contactid" link-type="outer">
                     <attribute name="fullname" alias="name"/>


### PR DESCRIPTION
<!--
  Is this related to a ticket in Jira? If so, add Smart Commit commands to the
  PR title to be automatically included in the merge commit if the PR is merged.

  For example:

  MT3-221 #ready-for-test #comment Create a pull request template

  https://confluence.atlassian.com/fisheye/using-smart-commits-960155400.html
  -->

# What?
Update CRM query to filter out ETRA records. We don't support either ETRA processes or ETRA tasks at the moment, so it's best to hide them for now.

All records that have nature of enquiry set to 28 (ETRA) are filtered out. Both ETRA meetings (processes) and ETRA meeting actions (tasks) have the same nature of enquiry value.
<!--
  What new features or changes does this pull request contain?

  Include before and after screenshots, if appropriate.
  -->

# Why?
Only records that can be dealt with at the moment are visible in the worktray
<!--
  What motivates these changes?

  Include any user stories driving this feature, if appropriate.
  -->

# Checklist

<!-- Add 'x' to the tests you've created and provide additional comments where useful.
     e.g. - [x] Cypress tests - Login & Logout user journeys -->

- [-] Unit tests
- [-] Integration tests
- [-] Cypress tests

# Notes
I didn't remove any ETRA specific handling from the app as we'll have to add that back soon anyway
<!--
  Is there anything about the implementation worth calling out to reviewers?
  -->

